### PR TITLE
switch to section/ins/del based diffs

### DIFF
--- a/01.md
+++ b/01.md
@@ -179,33 +179,18 @@ summary:     Initial version of the CountDown code
 </samp></pre>
 
 Let’s edit a file and see what happens.
-  <!-- edit text file module -->
-  <div class="edit1">
-    <div class="edittopbefore">
-    a.txt </div>
-    <div class="editcontent">
-      Scott Adams: Normal people believe that if it ain't
-      broke, don't fix it. Engineers believe that if it
-      ain't broke, it doesn't have enough features yet.
-    </div>
-    <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-  </div>
-  <div class="edit2">
-    <img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-    <div class="edittopafter">
-      a.txt
-    </div>
-    <div class="editcontent">
-      <strong>SCOTT ADAMS:</strong>
-      Normal people believe that if it ain't
-      broke, don't fix it. Engineers believe that if it
-      ain't broke, it doesn't have enough features yet.
-    </div>
-    <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-  </div>
-  <div style="clear: both;">&nbsp;</div>
-  <!-- end edit text file module -->
-  Now that we’ve made another change, we can commit it using **hg commit**:
+
+<section class="diff">
+<h3>a.txt</h3>
+<p>
+<del>Scott Adams</del><ins>SCOTT ADAMS</ins>: Normal people believe that if it ain't
+broke, don't fix it. Engineers believe that if it
+ain't broke, it doesn't have enough features yet.
+</p>
+</section>
+
+Now that we’ve made another change, we can commit it using **hg commit**:
+
 <pre><samp>
 <span class="prompt">c:\hginit\CountDown> </span><kbd>hg commit</kbd>
 
@@ -234,28 +219,15 @@ Like any modern blogger, Mercurial puts the newest stuff on top.
 
 I’m going to make one more change, just to amuse myself.
 
-  <div class="edit1">
-    <div class="edittopbefore">
-    a.txt </div>
-    <div class="editcontent">
-      SCOTT ADAMS: Normal people believe that if it ain't
-      broke, don't fix it. Engineers believe that if it
-      ain't broke, it doesn't have enough features yet.
-    </div>
-    <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-  </div>
-  <div class="edit2">
-    <img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-    <div class="edittopafter">a.txt</div>
-    <div class="editcontent">
-      SCOTT ADAMS:
-      Normal people believe that if it <strong>isn't
-      broken</strong>, don't fix it. Engineers believe that if it
-      <strong>isn't broken</strong>, it doesn't have enough features yet.
-    </div>
-    <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-  </div>
-  <div style="clear: both;">&nbsp;</div>
+<section class="diff">
+<h3>a.txt</h3>
+<p>
+SCOTT ADAMS: Normal people believe that if it <del>ain't broke</del><ins>isn't broken</ins>,
+don't fix it. Engineers believe that if it
+<del>ain't broke</del><ins>isn't broken</ins>, it doesn't have enough features yet.
+</p>
+</section>
+
 Committing:
 
 <pre><samp>
@@ -293,28 +265,13 @@ Patience, young grasshopper. You’re about to learn how to get some benefit out
 
 Number one. Let’s say you make a huge mistake editing.
 
-  <!-- edit text file module -->
-  <div class="edit1">
-    <div class="edittopbefore">
-    a.txt </div>
-    <div class="editcontent">
-      SCOTT ADAMS: Normal people believe that if it isn't
-      broken, don't fix it. Engineers believe that if it
-      isn't broken, it doesn't have enough features yet.
-    </div>
-    <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-  </div>
-  <div class="edit2">
-    <img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-    <div class="edittopafter">a.txt</div>
-    <div class="editcontent">
-      <strong>DAN QUAYLE: Illegitimacy is something we should
-      talk about in terms of not having it.</strong>
-    </div>
-    <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-  </div>
-  <div style="clear: both;">&nbsp;</div>
-  <!-- end edit text file module -->
+<section class="diff">
+<h3>a.txt</h3>
+<p>
+<del>SCOTT ADAMS: Normal people believe that if it isn't broken, don't fix it. Engineers believe that if it isn't broken, it doesn't have enough features yet.</del>
+<ins>DAN QUAYLE: Illegitimacy is something we should talk about in terms of not having it.</ins>
+</p>
+</section>
 
 And then, gosh, just for good measure you delete a couple of
 really important files.

--- a/02.md
+++ b/02.md
@@ -69,10 +69,9 @@ updating to branch default
 
 Now I’ll create a file called **guac** with my famous guacamole recipe.
 
-<div class="edit1">
-                <div class="edittopbefore" >
-                guac </div>
-                <div class="editcontent">
+<section class="diff">
+<h3>guac</h3>
+<p>
 * 2 ripe avocados<br>
 * 1/2 red onion, minced (about 1/2 cup)<br>
 * 1-2 serrano chiles, stems and seeds removed, minced<br>
@@ -84,11 +83,8 @@ Now I’ll create a file called **guac** with my famous guacamole recipe.
 
 Crunch all ingredients together.<br>
 Serve with tortilla chips.<br>
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
- <div style="clear: both;">&nbsp;</div>
+</p>
+</section>
 
 I’ll add this file, and commit it as the first official version:
 
@@ -106,40 +102,17 @@ I’ll provide a commit comment:
 
 I’m just going to quickly edit this file and make one small change, so
 that we have a little bit of history in the repository.
-
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
-&#8230;<br>
+<section class="diff">
+<h3>guac</h3>
+<p>
+…<br>
 * A dash of freshly grated black pepper<br>
 * 1/2 ripe tomato, seeds and pulp removed, chopped<br><br>
 
-Crunch all ingredients together.<br>
+<ins>Smoosh</ins> all ingredients together.<br>
 Serve with tortilla chips.<br>
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-
-  <div class="editcontent">
-&#8230;<br>
-* A dash of freshly grated black pepper<br>
-* 1/2 ripe tomato, seeds and pulp removed, chopped<br><br>
-
-<strong>Smoosh</strong> all ingredients together.<br>
-Serve with tortilla chips.<br>
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
+</p>
+</section>
 
 And now to commit that change:
 
@@ -196,19 +169,15 @@ ssl required
 </samp></pre>
 
 Oh great. It figures that wouldn’t work. I neglected to think about the security implications of just running a random web server and allowing anybody in the world to push their stupid changes into it. Bear with me for a moment; I’m going to configure that server to allow anybody in the world to do anything they want to it. This can be done by editing the file .hg\hgrc on the server:
-<div class="edit1">
-                <div class="edittopbefore">
-                .hg\hgrc </div>
-                <div class="editcontent">
-                    [web]<br />
-                    push_ssl=False<br />
-                    allow_push=*<br />
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
 
- <div style="clear: both;">&nbsp;</div>
-
+<section class="diff">
+<h3>.hg\hgrc</h3>
+<p>
+[web]<br />
+push_ssl=False<br />
+allow_push=*<br />
+</p>
+</section>
 Needless to say, this is rather unsafe, but if you’re on a nice protected LAN at work and there’s a good firewall and you trust everybody on your LAN, this is reasonably OK. Otherwise, you’ll want to read the advanced chapters on security.
 
 OK, time to fire up the server again:
@@ -291,39 +260,17 @@ Notice that when she types **hg log** she sees the whole history. She has actual
 
 Rose is going to make a change, and check it in:
 
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
+<section class="diff">
+<h3>guac</h3>
+<p>
 * 2 ripe avocados<br>
 * 1/2 red onion, minced (about 1/2 cup)<br>
-* 1-2 serrano chiles, stems and seeds removed, minced<br>
+* 1-2 <ins>habanero</ins> chiles, stems and seeds removed, minced<br>
 * 2 tablespoons cilantro leaves, finely chopped<br>
 * 1 tablespoon of fresh lime or lemon juice<br>
-&#8230;
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-  <div class="editcontent">
-* 2 ripe avocados<br>
-* 1/2 red onion, minced (about 1/2 cup)<br>
-* 1-2 <strong>habanero</strong> chiles, stems and seeds removed, minced<br>
-* 2 tablespoons cilantro leaves, finely chopped<br>
-* 1 tablespoon of fresh lime or lemon juice<br>
-&#8230;<br>
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
-
+…<br>
+</p>
+</section>
 
 Now she commits it. Notice that she can do this even if the server is not running: the commit entirely happens on her machine.
 
@@ -363,37 +310,17 @@ summary:     Initial version of guacamole recipe
 
 While Rose was making her change, I can make a change at the same time.
 
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
-&#8230;<br>
-* 1/2 ripe tomato, seeds and pulp removed, chopped<br><br>
-
-Smoosh all ingredients together.<br>
-Serve with tortilla chips.<br>
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-  <div class="editcontent">
-&#8230;<br>
+<section class="diff">
+<h3>guac</h3>
+<p>
+…<br>
 * 1/2 ripe tomato, seeds and pulp removed, chopped<br><br>
 
 Smoosh all ingredients together.
 
-Serve with <strong>potato</strong> chips.
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
+Serve with <ins>potato</ins> chips.
+</p>
+</section>
 
 After I check that in, you’ll see that my log shows something different as changeset #2 than Rose’s log.
 

--- a/03.md
+++ b/03.md
@@ -3,7 +3,7 @@ title: Fixing Goofs
 description: |
   One of the biggest benefits of Mercurial is that you can
   use private clones to try experiments and develop new
-  features… if they don&#8217;t work out, you can
+  features… if they don't work out, you can
   reverse them in a second.
 layout: article
 previous: 02.html
@@ -18,51 +18,22 @@ alternate:
 
 Mercurial lets you experiment freely. Imagine that during the course of normal editing, you get into trouble with your editor and do something catastrophic:
 
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
-* 2 ripe avocados<br>
+<section class="diff">
+<h3>guac</h3>
+<p>
+* 2 <del>ripe avocados</del><ins>iperay avocadosway</ins><br>
 * 1/2 red onion, minced (about 1/2 cup)<br>
 * 1-2 habanero chiles, stems and seeds removed, minced<br>
 * 2 tablespoons cilantro leaves, finely chopped<br>
 * 1 tablespoon of fresh lime or lemon juice<br>
 * 1/2 teaspoon coarse salt<br>
 * A dash of freshly grated black pepper<br>
-* 1/2 ripe tomato, seeds and pulp removed, chopped<br><br>
-
-Smoosh all ingredients together.<br>
-Serve with potato chips.<br>
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-  <div class="editcontent">
- * 2 iperay avocadosway<br>
-* 1/2 edray onionway, incedmay (aboutway 1/2 upcay)<br>
-* 1-2 abanerohay ileschay, emsstay andway eedssay <br>
-  emovedray, incedmay<br>
-* 2 ablespoonstay ilantrocay eaveslay, inelyfay oppedchay<br>
-* 1 ablespoontay ofway eshfray imelay orway emonlay <br>
-  uicejay
-* 1/2 easpoontay oarsecay altsay<br>
-* Away ashday ofway eshlyfray atedgray ackblay epperpay<br>
-* 1/2 iperay omatotay, eedssay andway ulppay emovedray, <br>
-  oppedchay<br><br>
-
-Ooshsmay allway ingredientsway ogethertay.<br>
-Ervesay ithway otatopay ipschay.<br>
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
+* 1/2 ripe tomato, seeds and pulp removed, chopped<br>
+<br>
+<del>Smoosh all ingredients together</del><br><ins>Ooshsmay allway ingredientsway ogethertay</ins>.<br>
+<del>Serve with potato chips</del><br><ins>Ervesay ithway otatopay ipschay</ins>.<br>
+</p>
+</section>
 
 Gotta love emacs. Anyway, all is not lost. The most common way to recover from these things is just to **hg revert** them:
 
@@ -73,13 +44,13 @@ Gotta love emacs. Anyway, all is not lost. The most common way to recover from t
 %}
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg revert guac</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg revert guac</kbd>
 </samp></pre>
 
-That&#8217;ll put the files back exactly the way they were at the time of the last commit. Mercurial doesn&#8217;t like to delete anything, so instead of zapping the [Pig Latin](http://en.wikipedia.org/wiki/Pig_Latin) recipe, it renamed it:
+That'll put the files back exactly the way they were at the time of the last commit. Mercurial doesn't like to delete anything, so instead of zapping the [Pig Latin](http://en.wikipedia.org/wiki/Pig_Latin) recipe, it renamed it:
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>dir</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>dir</kbd>
  Volume in drive C has no label.
  Volume Serial Number is 84BD-9C2C
 
@@ -93,17 +64,17 @@ That&#8217;ll put the files back exactly the way they were at the time of the la
                2 File(s)            903 bytes
                3 Dir(s)  40,958,005,248 bytes free
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>del guac</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>del guac</kbd>
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>rename guac.orig guac</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>rename guac.orig guac</kbd>
 </samp></pre>
 
 What if you had gone one step too far and actually committed?
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg com -m "Pig Latin ftw"</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg com -m "Pig Latin ftw"</kbd>
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg log -l 3</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg log -l 3</kbd>
 changeset:   5:c7af1973de6d
 tag:         tip
 user:        Joel Spolsky &lt;joel@joelonsoftware.com&gt;
@@ -132,13 +103,13 @@ summary:     spicier kind of chile
   text="undoes one commit, as long as you haven't pushed it to anyone else."
 %}
 
-There&#8217;s a command called **hg rollback** which will save your skin, but only if you haven&#8217;t pushed this change to anyone else. It only undoes __one__ commit.
+There's a command called **hg rollback** which will save your skin, but only if you haven't pushed this change to anyone else. It only undoes __one__ commit.
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg rollback</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg rollback</kbd>
 rolling back last transaction
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg log -l 3</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg log -l 3</kbd>
 changeset:   4:0849ca96c304
 tag:         tip
 parent:      2:4ecdb2401ab4
@@ -159,25 +130,25 @@ date:        Mon Feb 08 15:32:01 2010 -0500
 summary:     potato chips. No one can eat just one.
 
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg stat</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg stat</kbd>
 M guac
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg revert guac</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg revert guac</kbd>
 </samp></pre>
 
-Imagine you want to do a major experiment on the side. Your boss hired a new designer, Jim, and lately the specs you&#8217;ve been getting from him are just absurd. There&#8217;s fluorescent green text, nothing lines up (for &#8220;artistic&#8221; reasons), and the usability is awful. You want to come in one weekend and redo the whole thing, but you&#8217;re afraid to commit it because you&#8217;re not really 100% sure that your ideas are better than this nutty graphic designer. Jim is basically smoking a joint from the moment he wakes up until he goes to bed. You don&#8217;t want to hold that against him, and everybody else thinks that it&#8217;s nobody&#8217;s business as long as his designs are good, but really, there&#8217;s a limit. Right? And his designs aren&#8217;t good. Plus he&#8217;s kind of offensive.
+Imagine you want to do a major experiment on the side. Your boss hired a new designer, Jim, and lately the specs you've been getting from him are just absurd. There's fluorescent green text, nothing lines up (for &#8220;artistic&#8221; reasons), and the usability is awful. You want to come in one weekend and redo the whole thing, but you're afraid to commit it because you're not really 100% sure that your ideas are better than this nutty graphic designer. Jim is basically smoking a joint from the moment he wakes up until he goes to bed. You don't want to hold that against him, and everybody else thinks that it's nobody's business as long as his designs are good, but really, there's a limit. Right? And his designs aren't good. Plus he's kind of offensive.
 
 With Mercurial, you can just make an experimental clone of the entire repository:
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>cd ..</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>cd ..</kbd>
 
 C:\Users\joel&gt; <strong>hg clone recipes recipes-experiment</strong>
 updating to branch default
 1 files updated, 0 files merged, 0 files removed, 0 files unresolved
 </samp></pre>
 
-This isn&#8217;t as inefficient as it seems. Because both **recipes** and **recipes-experiment** share all their history (so far), Mercurial will use a file system trick called &#8220;hard links&#8221; so that the copy can be created very quickly, without taking up a lot of extra space on disk.
+This isn't as inefficient as it seems. Because both **recipes** and **recipes-experiment** share all their history (so far), Mercurial will use a file system trick called &#8220;hard links&#8221; so that the copy can be created very quickly, without taking up a lot of extra space on disk.
 
 Now we can make a bunch of changes in the experimental branch:
 
@@ -185,53 +156,32 @@ Now we can make a bunch of changes in the experimental branch:
 C:\Users\joel&gt; <strong>cd recipes-experiment</strong>
 </samp></pre>
 
-Here&#8217;s my grand guacamole experiment:
+Here's my grand guacamole experiment:
 
-   <div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
-                …<br><br>
-
+<section class="diff">
+<h3>a.txt</h3>
+<p>
+…<br>
 Smoosh all ingredients together.<br>
 Serve with potato chips.<br>
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
 
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-  <div class="editcontent">
-…<br><br>
-
-Smoosh all ingredients together.<br>
-Serve with potato chips.<br><br>
-
-<strong>This recipe is really good served with QUESO.<br><br>
+<ins>This recipe is really good served with QUESO.<br><br>
 
 QUESO is Spanish for "cheese," but in Texas,
 it's just Kraft Slices melted in the microwave
-with some salsa from a jar. MMM!</strong><br>
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
-
+with some salsa from a jar. MMM!</ins>
+</p>
+</section>
 
 Here in the experimental repository, we can commit freely.
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes-experiment> </span> <kbd>hg com -m "Queso = Cheese!"</kbd>
+<span class=prompt>C:\Users\joel\recipes-experiment> </span><kbd>hg com -m "Queso = Cheese!"</kbd>
 </samp></pre>
 
 You can make changes and work freely, committing whenever you want. That gives you all the power of source control even for your crazy experiment, without infecting anyone else.
 
-If you decide that the experiment was misguided, you can just delete the whole experimental directory. Problem solved. It&#8217;s gone.
+If you decide that the experiment was misguided, you can just delete the whole experimental directory. Problem solved. It's gone.
 
 But if it worked, all you have to do is push your new changes:
 
@@ -257,16 +207,16 @@ text="shows a list of known remote repositories "
 default = c:\Users\joel\recipes
 </samp></pre>
 
-The &#8220;default&#8221; entry there shows you the path to the repository that **hg push** will push changes to, if you don&#8217;t specify any other repository. Normally, that&#8217;s the repository that you cloned off of. In this case, it&#8217;s a local directory, but you could also have a URL there.
+The &#8220;default&#8221; entry there shows you the path to the repository that **hg push** will push changes to, if you don't specify any other repository. Normally, that's the repository that you cloned off of. In this case, it's a local directory, but you could also have a URL there.
 
 <pre><samp>
 <span class=prompt>C:\Users\joel\recipes-experiment> </span><kbd>cd ..\recipes</kbd>
 </samp></pre>
 
-Don&#8217;t forget, just because the change has been pushed into this __repository__…
+Don't forget, just because the change has been pushed into this __repository__…
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg log -l 3</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg log -l 3</kbd>
 changeset:   5:9545248f3fc9
 tag:         tip
 user:        Joel Spolsky &lt;joel@joelonsoftware.com&gt;
@@ -287,10 +237,10 @@ date:        Mon Feb 08 15:29:09 2010 -0500
 summary:     spicier kind of chile
 </samp></pre>
 
-… doesn&#8217;t mean we&#8217;re working off that version yet.
+… doesn't mean we're working off that version yet.
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>type guac</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>type guac</kbd>
 * 2 ripe avocados
 * 1/2 red onion, minced (about 1/2 cup)
 * 1-2 habanero chiles, stems and seeds removed, minced
@@ -303,7 +253,7 @@ summary:     spicier kind of chile
 Smoosh all ingredients together.
 Serve with potato chips.
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg parent</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg parent</kbd>
 changeset:   4:0849ca96c304
 parent:      2:4ecdb2401ab4
 parent:      3:689026657682
@@ -317,19 +267,19 @@ command="hg parent"
 text="shows which changeset(s) you're working off of"
 %}
 
-See? That &#8220;Queso&#8221; stuff is in changeset 5. But my main repository was working off of changeset 4, and just because someone pushed new changes into the __repository__, doesn&#8217;t mean they&#8217;ve showed up in my working directory yet, so I&#8217;m still working off of changeset 4.
+See? That &#8220;Queso&#8221; stuff is in changeset 5. But my main repository was working off of changeset 4, and just because someone pushed new changes into the __repository__, doesn't mean they've showed up in my working directory yet, so I'm still working off of changeset 4.
 
 
 ![](i/03-repo.png)
 
 
-If I want to see what&#8217;s in changeset 5, I have to use the **hg update** command:
+If I want to see what's in changeset 5, I have to use the **hg update** command:
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg up</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg up</kbd>
 1 files updated, 0 files merged, 0 files removed, 0 files unresolved
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg parent</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg parent</kbd>
 changeset:   5:9545248f3fc9
 tag:         tip
 user:        Joel Spolsky &lt;joel@joelonsoftware.com&gt;
@@ -337,7 +287,7 @@ date:        Thu Feb 11 12:59:11 2010 -0500
 summary:     Queso = Cheese!
 
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>type guac</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>type guac</kbd>
 * 2 ripe avocados
 * 1/2 red onion, minced (about 1/2 cup)
 * 1-2 habanero chiles, stems and seeds removed, minced
@@ -357,9 +307,9 @@ it's just Kraft Slices melted in the microwave
 with some salsa from a jar. MMM!
 </samp></pre>
 
-See what happened here? The changes came in, but they were on top of the version I was working on. <strong>push</strong> and <strong>pull</strong> just send changes from one repo to another&#8212;they don&#8217;t affect the files I&#8217;m working on at the moment.
+See what happened here? The changes came in, but they were on top of the version I was working on. <strong>push</strong> and <strong>pull</strong> just send changes from one repo to another&#8212;they don't affect the files I'm working on at the moment.
 
-Right now here&#8217;s the state of repositories:
+Right now here's the state of repositories:
 
 
 ![](i/03-repo-2.png)
@@ -368,7 +318,7 @@ Right now here&#8217;s the state of repositories:
 Mercurial is flexible about moving changes around from repository to repository. You can push straight from the experimental repository into the central repository:
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>cd ..\recipes-experiment</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>cd ..\recipes-experiment</kbd>
 
 <span class=prompt>C:\Users\joel\recipes-experiment> </span>
 
@@ -393,25 +343,25 @@ adding file changes
 added 1 changesets with 1 changes to 1 files
 </samp></pre>
 
-That pushed change 5 from the experimental repo directly into the central repository. Now, if I go back to my repository, there&#8217;s nothing left to push!
+That pushed change 5 from the experimental repo directly into the central repository. Now, if I go back to my repository, there's nothing left to push!
 
 <pre><samp>
 <span class=prompt>C:\Users\joel\recipes-experiment> </span><kbd>cd ..\recipes</kbd>
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg out</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg out</kbd>
 comparing with http://joel.example.com:8000/
 searching for changes
 no changes found
 </samp></pre>
 
-That&#8217;s because Mercurial knows that the central repo already got this particular changeset from somewhere else. That&#8217;s really useful, because otherwise it would try to apply it again, and it would be massively confused.
+That's because Mercurial knows that the central repo already got this particular changeset from somewhere else. That's really useful, because otherwise it would try to apply it again, and it would be massively confused.
 
-After they made a job offer to designer Jim, he said he would start work right away, but then he didn&#8217;t show up for two months. People had mostly forgotten about him and about the job offer, and when he showed up at the office for the first time to start work, looking rather sunburned, to be honest, nobody quite knew who he was or what was going on. It was pretty funny. He is kind of a generic looking guy. Eventually they figured it out, but since he was new, nobody had the guts to ask him what the hell had happened. Just like they never ask him about the bruises and scratches on his face. Whatever. We hate that guy.
+After they made a job offer to designer Jim, he said he would start work right away, but then he didn't show up for two months. People had mostly forgotten about him and about the job offer, and when he showed up at the office for the first time to start work, looking rather sunburned, to be honest, nobody quite knew who he was or what was going on. It was pretty funny. He is kind of a generic looking guy. Eventually they figured it out, but since he was new, nobody had the guts to ask him what the hell had happened. Just like they never ask him about the bruises and scratches on his face. Whatever. We hate that guy.
 
 Sometimes it may happen that you discover that, months earlier, you made a mistake.
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg diff -r 1:2 guac</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg diff -r 1:2 guac</kbd>
 diff -r a52881ed530d -r 4ecdb2401ab4 guac
 --- a/guac      Mon Feb 08 14:51:18 2010 -0500
 +++ b/guac      Mon Feb 08 15:32:01 2010 -0500
@@ -425,10 +375,10 @@ diff -r a52881ed530d -r 4ecdb2401ab4 guac
 
 Potato chips? WTF?!
 
-Mercurial can backout an old changeset from the past for you. It looks at the changeset, figures out the __opposite__, and does that to your current working directory. Let&#8217;s try backing out that old revision 2.
+Mercurial can backout an old changeset from the past for you. It looks at the changeset, figures out the __opposite__, and does that to your current working directory. Let's try backing out that old revision 2.
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg backout -r 2 --merge</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg backout -r 2 --merge</kbd>
 reverting guac
 created new head
 changeset 6:d828920f7f85 backs out changeset 2:4ecdb2401ab4
@@ -441,7 +391,7 @@ merging guac
 Holy crap, what just happened?
 
 <pre><samp>
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg diff</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg diff</kbd>
 diff -r 9545248f3fc9 guac
 --- a/guac      Thu Feb 11 12:59:11 2010 -0500
 +++ b/guac      Thu Feb 11 14:19:34 2010 -0500
@@ -454,9 +404,9 @@ diff -r 9545248f3fc9 guac
 
  This recipe is really good served with QUESO.
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg com -m &quot;undo thing from the past&quot;</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg com -m &quot;undo thing from the past&quot;</kbd>
 
-<span class=prompt>C:\Users\joel\recipes> </span> <kbd>hg push</kbd>
+<span class=prompt>C:\Users\joel\recipes> </span><kbd>hg push</kbd>
 pushing to http://joel.example.com:8000/
 searching for changes
 adding changesets

--- a/04.html
+++ b/04.html
@@ -35,34 +35,15 @@ added 2 changesets with 2 changes to 1 files
 <p>Now an edit:</p>
 
 
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
-* 2 ripe avocados<br>
+<section class="diff">
+<h3>guac</h3>
+<p>
+* 2 ripe <ins>Hass</ins> avocados <ins>(not Haas)</ins><br>
 * 1/2 red onion, minced (about 1/2 cup)<br>
 * 1-2 habanero chiles, stems and seeds removed, minced<br>
-&#8230;
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-  <div class="editcontent">
-* 2 ripe <strong>Hass </strong>avocados<strong> (not Haas)</strong><br>
-* 1/2 red onion, minced (about 1/2 cup)<br>
-* 1-2 habanero chiles, stems and seeds removed, minced<br>
-&#8230;
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
+…
+</p>
+</section>
 
 <p>She commits and pushes the change off to the central repository:</p>
 
@@ -91,35 +72,15 @@ added 1 changesets with 1 changes to 1 files
 
 <p>Simultaneously, I make a change in a different part of the file:</p>
 
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
+<section class="diff">
+<h3>guac</h3>
+<p>
 * 2 ripe avocados<br>
 * 1/2 red onion, minced (about 1/2 cup)<br>
-* 1-2 habanero chiles, stems and seeds removed, minced<br>
-&#8230;
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-  <div class="editcontent">
-* 2 ripe avocados<br>
-* 1/2 red onion, minced (about 1/2 cup)<br>
-* 1-2 <strong>jalapeno</strong> chiles, stems and seeds removed, minced<br>
-&#8230;
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
-
+* 1-2 <ins>jalapeno</ins> chiles, stems and seeds removed, minced<br>
+…
+</p>
+</section>
 
 <p>I can commit, but I can&#8217;t push to the central repository.</p>
 
@@ -303,33 +264,9 @@ added 2 changesets with 2 changes to 1 files
 
 <p>I added a banana:</p>
 
-
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
-* 2 ripe Hass avocados (not Haas)<br>
-* 1/2 red onion, minced (about 1/2 cup)<br>
-* 1-2 jalapeno chiles, stems and seeds removed, minced<br>
-* 2 tablespoons cilantro leaves, finely chopped<br>
-* 1 tablespoon of fresh lime or lemon juice<br>
-* 1/2 teaspoon coarse salt<br>
-* A dash of freshly grated black pepper<br>
-* 1/2 ripe tomato, seeds and pulp removed, chopped<br><br>
-
-Smoosh all ingredients together.<br>
-Serve with tortilla chips.<br>
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-  <div class="editcontent">
+<section class="diff">
+<h3>guac</h3>
+<p>
 * 2 ripe Hass avocados (not Haas)<br>
 * 1/2 red onion, minced (about 1/2 cup)<br>
 * 1-2 jalapeno chiles, stems and seeds removed, minced<br>
@@ -338,16 +275,11 @@ Serve with tortilla chips.<br>
 * 1/2 teaspoon coarse salt<br>
 * A dash of freshly grated black pepper<br>
 * 1/2 ripe tomato, seeds and pulp removed, chopped<br>
- <strong>* 1 delicious, yellow BANANA.
-</strong><br><br>
+<ins>* 1 delicious, yellow BANANA.</ins><br><br>
 Smoosh all ingredients together.<br>
 Serve with tortilla chips.
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
-
+</p>
+</section>
 
 <p>I checked in the banana change first:</p>
 
@@ -378,32 +310,9 @@ added 1 changesets with 1 changes to 1 files
 
 <p>And Rose, bless her heart, added a MANGO on the EXACT SAME LINE.</p>
 
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
- * 2 ripe Hass avocados (not Haas)<br>
-* 1/2 red onion, minced (about 1/2 cup)<br>
-* 1-2 jalapeno chiles, stems and seeds removed, minced<br>
-* 2 tablespoons cilantro leaves, finely chopped<br>
-* 1 tablespoon of fresh lime or lemon juice<br>
-* 1/2 teaspoon coarse salt<br>
-* A dash of freshly grated black pepper<br>
-* 1/2 ripe tomato, seeds and pulp removed, chopped<br><br>
-
-Smoosh all ingredients together.<br>
-Serve with tortilla chips.<br>
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-  <div class="editcontent">
+<section class="diff">
+<h3>guac</h3>
+<p>
 * 2 ripe Hass avocados (not Haas)<br>
 * 1/2 red onion, minced (about 1/2 cup)<br>
 * 1-2 jalapeno chiles, stems and seeds removed, minced<br>
@@ -412,16 +321,11 @@ Serve with tortilla chips.<br>
 * 1/2 teaspoon coarse salt<br>
 * A dash of freshly grated black pepper<br>
 * 1/2 ripe tomato, seeds and pulp removed, chopped<br>
-<strong>* 1 ripe young Mango, in season.<br><br>
-</strong>
+<ins>* 1 ripe young Mango, in season.</ins><br><br>
 Smoosh all ingredients together.<br>
 Serve with tortilla chips.<br>
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
-
+</p>
+</section>
 
 <p>&#8220;Ripe young&#8221; mango, indeed.</p>
 

--- a/05.html
+++ b/05.html
@@ -90,11 +90,12 @@ summary:     merge
 
 <p>The rest of us went back to our cubes, to work on Guac 2.0.</p>
 
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
-* 2 ripe Hass avocados (not Haas)<br />
+<section class="diff">
+<h3>guac</h3>
+<p>
+<ins>GUACAMOLE 2.0 THIS IS GOING TO BE AWESOME</ins><br /><br />
+
+* 2<ins>00</ins> ripe Hass avocados (not Haas)<br />
 * 1/2 red onion, minced (about 1/2 cup)<br />
 * 1-2 jalapeno chiles, stems and seeds removed, minced<br />
 * 2 tablespoons cilantro leaves, finely chopped<br />
@@ -104,34 +105,8 @@ summary:     merge
 * 1/2 ripe tomato, seeds and pulp removed, chopped<br />
 * 1 ripe young Mango, in season.<br />
 * 1 delicious, yellow BANANA.<br />
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-  <div class="editcontent">
-<strong>GUACAMOLE 2.0 THIS IS GOING TO BE AWESOME</strong><br /><br />
-
-* 2<strong>00</strong> ripe Hass avocados (not Haas)<br />
-* 1/2 red onion, minced (about 1/2 cup)<br />
-* 1-2 jalapeno chiles, stems and seeds removed, minced<br />
-* 2 tablespoons cilantro leaves, finely chopped<br />
-* 1 tablespoon of fresh lime or lemon juice<br />
-* 1/2 teaspoon coarse salt<br />
-* A dash of freshly grated black pepper<br />
-* 1/2 ripe tomato, seeds and pulp removed, chopped<br />
-* 1 ripe young Mango, in season.<br />
-* 1 delicious, yellow BANANA.<br />
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
+</p>
+</section>
 
 <p>Commit:</p>
 
@@ -158,47 +133,21 @@ summary:     merge
 
 <p>And now I can fix his stupid salt problem:</p>
 
-<div class="edit1">
-                <div class="edittopbefore">
-                guac </div>
-                <div class="editcontent">
+<section class="diff">
+<h3>guac</h3>
+<p>
 * 2 ripe Hass avocados (not Haas)<br />
 * 1/2 red onion, minced (about 1/2 cup)<br />
 * 1-2 jalapeno chiles, stems and seeds removed, minced<br />
 * 2 tablespoons cilantro leaves, finely chopped<br />
 * 1 tablespoon of fresh lime or lemon juice<br />
-* 1/2 teaspoon coarse salt<br />
+* <ins>1 grain table </ins>salt<ins>, split in half</ins><br />
 * A dash of freshly grated black pepper<br />
 * 1/2 ripe tomato, seeds and pulp removed, chopped<br />
 * 1 ripe young Mango, in season.<br />
 * 1 delicious, yellow BANANA.<br />
-                </div>
-                <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
-    </div>
-
-
-<div class="edit2">
-	<img src="i/arrow2.gif" width="83" height="97" class="editArrow" alt="Image of an arrow swooping down and to the right." />
-	<div class="edittopafter">
-		guac
-	</div>
-    <div class="editcontent">
-* 2 ripe Hass avocados (not Haas)<br />
-* 1/2 red onion, minced (about 1/2 cup)<br />
-* 1-2 jalapeno chiles, stems and seeds removed, minced<br />
-* 2 tablespoons cilantro leaves, finely chopped<br />
-* 1 tablespoon of fresh lime or lemon juice<br />
-* <strong>1 grain table </strong>salt<strong>, split in half</strong><br />
-* A dash of freshly grated black pepper<br />
-* 1/2 ripe tomato, seeds and pulp removed, chopped<br />
-* 1 ripe young Mango, in season.<br />
-* 1 delicious, yellow BANANA.<br />
-   </div>
-  <img src="i/edit-bot.gif" width="387" height="76" alt="Image portraying the bottom of a sheet of paper with one corner folded." />
- </div>
-
- <div style="clear: both;">&nbsp;</div>
-
+</p>
+</section>
 
 <p>And:</p>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -244,29 +244,13 @@ pre.rose:before {
   background: url(/i/code-rose-middle.png) top left
     repeat-y;
 }
-pre kbd {
-  font-weight: 600;
-}
-div.edit1 {
-  z-index: -1;
-  float: left;
-  margin-top: 0;
-  margin-left: 10px;
-  width: 384px;
-}
-div.edit2 {
-  float: left;
-  margin-top: -70px;
-  margin-left: 100px;
-  z-index: 1;
-  width: 384px;
-}
 
+/* Styles for diffs */
 .diff {
-  width: 400px;
+  width: 500px;
   border: solid 1px #000;
 }
-div.edittopbefore, .diff h3 {
+.diff h3 {
   font-size: 14px;
   margin: 0;
   height: 21px;
@@ -275,44 +259,30 @@ div.edittopbefore, .diff h3 {
   color: #fff;
   font-weight: 700;
   padding-left: 15px;
-  border-radius: 3px 3px 0 0;
 }
 
 .diff p{
+  padding: 5px 10px;
   font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
   font-size: 14px;
 }
 
-.editcontent p{
-    border-left: solid 1px #000;
-  border-right: solid 1px #000;
-}
-div.editcontent {
-
-  font-size: 14px;
-/*  margin-left: 1px;*/
-  height: auto;
-/*  border-left: solid 1px #000;*/
-/*  border-right: solid 1px #000;*/
-  color: #000;
-  padding-top: 5px;
-  padding-bottom: 76px;
-  padding-left: 15px;
-  background: url('/i/edit-bot.gif') bottom left no-repeat;
-}
-div.editcontent strong, .editcontent ins, .diff ins {
-  text-decoration: none;
+.diff ins {
+  text-decoration: none; /* default underlines */
   background-color: #ff0;
 }
 
 /*
   See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins#accessibility_concerns
-  The presence of the <ins> element is not announced by most screen reading technology
+  and https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del#accessibility_concerns
+  The presence of the <ins>/<del> element is not announced by most screen reading technology
   in its default configuration. It can be made to be announced by using the CSS
   content property, along with the ::before and ::after pseudo-elements.
 */
 ins::before,
-ins::after {
+ins::after,
+del::before,
+del::after {
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
@@ -330,26 +300,16 @@ ins::after {
   content: " [insertion end] ";
 }
 
-div.edittopafter {
-  font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console,
-    monospace;
-  font-size: 14px;
-  margin-left: 1px;
-  height: 21px;
-  background: transparent url(/i/editTopAfter.gif)
-    repeat-x;
-  border: solid 1px #000;
-  color: #fff;
-  font-weight: 700;
-  padding-left: 15px;
-  margin-top: -97px;
-  border-radius: 3px 3px 0 0;
+
+del::before {
+  content: " [deletion start] ";
 }
-img.editArrow {
-  left: -80px;
-  position: relative;
-  z-index: 2;
+
+del::after {
+  content: " [deletion end] ";
 }
+
+
 footer {
   margin-top: 30px;
   width: 630px;

--- a/public/styles.css
+++ b/public/styles.css
@@ -261,9 +261,14 @@ div.edit2 {
   z-index: 1;
   width: 384px;
 }
-div.edittopbefore {
+
+.diff {
+  width: 400px;
+  border: solid 1px #000;
+}
+div.edittopbefore, .diff h3 {
   font-size: 14px;
-  margin-left: 1px;
+  margin: 0;
   height: 21px;
   background-color: #666;
   border: solid 1px #000;
@@ -272,25 +277,59 @@ div.edittopbefore {
   padding-left: 15px;
   border-radius: 3px 3px 0 0;
 }
-div.editcontent {
-  font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console,
-    monospace;
+
+.diff p{
+  font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
   font-size: 14px;
-  margin-left: 1px;
-  height: auto;
-  background-color: #fff;
-  border-left: solid 1px #000;
+}
+
+.editcontent p{
+    border-left: solid 1px #000;
   border-right: solid 1px #000;
+}
+div.editcontent {
+
+  font-size: 14px;
+/*  margin-left: 1px;*/
+  height: auto;
+/*  border-left: solid 1px #000;*/
+/*  border-right: solid 1px #000;*/
   color: #000;
   padding-top: 5px;
+  padding-bottom: 76px;
   padding-left: 15px;
+  background: url('/i/edit-bot.gif') bottom left no-repeat;
 }
-div.editcontent strong {
-  font-weight: 400;
+div.editcontent strong, .editcontent ins, .diff ins {
+  text-decoration: none;
   background-color: #ff0;
-  font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console,
-    monospace;
 }
+
+/*
+  See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins#accessibility_concerns
+  The presence of the <ins> element is not announced by most screen reading technology
+  in its default configuration. It can be made to be announced by using the CSS
+  content property, along with the ::before and ::after pseudo-elements.
+*/
+ins::before,
+ins::after {
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+ins::before {
+  content: " [insertion start] ";
+}
+
+ins::after {
+  content: " [insertion end] ";
+}
+
 div.edittopafter {
   font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console,
     monospace;


### PR DESCRIPTION
The edit styling was based on complex divs, and multiple image tags. This changes to a simple section + del/ins tag based model.

Ref: #6.

Turns out `<ins>` and `<del>` aren't really that accessible by default, since it's too verbose, so we use the suggested styles by MDN.

